### PR TITLE
fix: update int-api default port 3003 -> 3004

### DIFF
--- a/self-host/advanced/config-file.mdx
+++ b/self-host/advanced/config-file.mdx
@@ -110,7 +110,7 @@ This section contains the complete reference for all configuration options in `c
     <ResponseField name="integration_port" type="integer">
       The port for the integration API (optional).
 
-      **Example**: `3003`
+      **Example**: `3004`
     </ResponseField>
 
     <ResponseField name="internal_hostname" type="string">

--- a/self-host/advanced/integration-api.mdx
+++ b/self-host/advanced/integration-api.mdx
@@ -14,11 +14,11 @@ flags:
   enable_integration_api: true
 ```
 
-If you want to specify a port other than the default `3003`, you can do so in the config as well:
+If you want to specify a port other than the default `3004`, you can do so in the config as well:
 
 ```yaml title="config.yml"
 server:
-  integration_port: 3003 # Specify different port
+  integration_port: 3004 # Specify different port
 ```
 
 ## Configure Traefik Routing
@@ -53,7 +53,7 @@ http:
     int-api-service:
       loadBalancer:
         servers:
-          - url: "http://pangolin:3003"
+          - url: "http://pangolin:3004"
 ```
 
 ## Access Documentation


### PR DESCRIPTION
Updates the default port for the integration API from 3003 to 3004. 