### PR TITLE
Update OIDC Docs for IdP alias guidance for self-hosted OIDC behind Pangolin - Issue #3

### DIFF
--- a/manage/identity-providers/openid-connect.mdx
+++ b/manage/identity-providers/openid-connect.mdx
@@ -64,3 +64,60 @@ Determine how to access information from the claims token returned by the identi
   Generally, `openid profile email` is sufficient for most use cases.
   </Note>
 </ResponseField>
+
+## If your IdP is hosted behind the same Pangolin stack
+
+When your OpenID Connect (OIDC) provider is also served **through this Pangolin stack** (e.g. via Traefik on the same host) and your IdP URL like `https://idp.example.com` points to this host, containers in the stack must resolve the IdP hostname **internally** for callbacks and token exchanges.
+
+Add the IdP domain as a **Docker network alias** on the service exposing ports `80`/`443` inside the compose network:
+
+<Tabs>
+  <Tab title="Traefik shares gerbil netns">
+  Traefik uses `network_mode: service:gerbil` and therefore reuses gerbil's network namespace.
+  ```yaml
+  services:
+    gerbil:
+      networks:
+        default:
+          aliases:
+            - idp.example.com  # IdP hostname resolves internally
+      ports:
+        - 443:443
+        - 80:80
+
+    traefik:
+      network_mode: "service:gerbil"
+  ```
+  </Tab>
+  <Tab title="Traefik has own netns">
+  Traefik runs in its own namespace and directly exposes 80/443.
+  ```yaml
+  services:
+    traefik:
+      networks:
+        default:
+          aliases:
+            - idp.example.com
+      ports:
+        - 443:443
+        - 80:80
+  ```
+  </Tab>
+</Tabs>
+
+<Info>
+Public DNS remains unchanged. The alias only affects **internal service-to-service resolution** for OIDC redirects and token/userinfo requests.
+</Info>
+
+### When to add the alias
+
+* You host the IdP behind the same Traefik/Pangolin stack.
+* OIDC flows originate from containers that must reach the IdP hostname internally (authorization callback, token exchange, userinfo).
+
+### If Traefik runs elsewhere
+
+If Traefik is external (different host or Kubernetes), ensure internal DNS resolves the IdP domain appropriately (CoreDNS override, /etc/hosts, or service alias in that environment).
+
+<Tip>
+Remove the alias only if all OIDC flows successfully resolve the IdP via public DNS from within the stack (hairpin NAT working). Keeping the alias avoids edge cases.
+</Tip>

--- a/self-host/manual/docker-compose.mdx
+++ b/self-host/manual/docker-compose.mdx
@@ -317,3 +317,49 @@ http:
 ## Pangolin Configuration
 
 Create `config/config.yml` with your Pangolin settings. See the [configuration guide](/self-host/advanced/config-file) for detailed options and examples.
+
+
+## Internal DNS for a self-hosted IdP behind Pangolin
+
+If you also serve your OIDC provider through the **same Pangolin/Traefik stack**, add the IdP domain (e.g. `idp.example.com`) as a Docker network **alias** on the service exposing HTTP/HTTPS **inside** the compose network. This ensures in-stack callbacks and token/userinfo requests resolve without hair‑pinning out to the public internet.
+
+### Scenario A: Traefik shares gerbil network namespace
+Traefik attaches with `network_mode: service:gerbil`; expose alias on `gerbil`:
+
+```yaml
+services:
+  gerbil:
+    networks:
+      default:
+        aliases:
+          - idp.example.com
+    ports:
+      - 443:443
+      - 80:80
+
+  traefik:
+    network_mode: "service:gerbil"
+```
+
+### Scenario B: Traefik has its own network namespace
+Traefik runs independently; add alias on `traefik`:
+
+```yaml
+services:
+  traefik:
+    networks:
+      default:
+        aliases:
+          - idp.example.com
+    ports:
+      - 443:443
+      - 80:80
+```
+
+<Note>
+Public DNS does not change; the alias only augments internal container DNS resolution.
+</Note>
+
+<Tip>
+If OIDC flows fail internally with DNS errors or timeouts, verify the alias and that Traefik actually serves the IdP endpoints on 80/443.
+</Tip>


### PR DESCRIPTION
Summary by Copilot:

This pull request adds documentation to clarify how to configure internal DNS resolution for a self-hosted OpenID Connect (OIDC) provider when it is hosted behind the same Pangolin/Traefik stack. The new guidance helps ensure that service-to-service OIDC flows work correctly within the Docker Compose network by using network aliases for the IdP domain. This avoids issues where containers cannot resolve the IdP hostname internally, which can lead to authentication failures.

**OIDC Internal DNS Configuration:**

* Added instructions for adding the IdP domain as a Docker network alias on the service exposing ports `80`/`443` (typically `gerbil` or `traefik`) to ensure internal callbacks and token/userinfo requests resolve correctly within the stack. [[1]](diffhunk://#diff-215e3b0d2b3091a1d0ee671c7c7c700ecd9015111ede4938735d5b1448aef20cR67-R123) [[2]](diffhunk://#diff-240ebdf759820bc3b9e5cd83ffdfc591c2340227cdb9fcea3315f3a1416dc5f1R320-R365)
* Provided scenario-based examples for both cases: when Traefik shares the `gerbil` network namespace and when Traefik runs in its own namespace, including sample `docker-compose.yaml` snippets. [[1]](diffhunk://#diff-215e3b0d2b3091a1d0ee671c7c7c700ecd9015111ede4938735d5b1448aef20cR67-R123) [[2]](diffhunk://#diff-240ebdf759820bc3b9e5cd83ffdfc591c2340227cdb9fcea3315f3a1416dc5f1R320-R365)
* Clarified that public DNS remains unchanged and the alias only affects internal container DNS resolution for OIDC flows. [[1]](diffhunk://#diff-215e3b0d2b3091a1d0ee671c7c7c700ecd9015111ede4938735d5b1448aef20cR67-R123) [[2]](diffhunk://#diff-240ebdf759820bc3b9e5cd83ffdfc591c2340227cdb9fcea3315f3a1416dc5f1R320-R365)
* Added troubleshooting tips for DNS errors and guidance on when to remove the alias, emphasizing best practices to avoid edge cases with OIDC authentication. [[1]](diffhunk://#diff-215e3b0d2b3091a1d0ee671c7c7c700ecd9015111ede4938735d5b1448aef20cR67-R123) [[2]](diffhunk://#diff-240ebdf759820bc3b9e5cd83ffdfc591c2340227cdb9fcea3315f3a1416dc5f1R320-R365)


Closes #3 