### PR TITLE
docs: clarify blueprint behavior with docker

### DIFF
--- a/manage/blueprints.mdx
+++ b/manage/blueprints.mdx
@@ -177,6 +177,10 @@ client-resources:
 
 For containerized applications, you can define blueprints using Docker labels.
 
+<Note>
+Blueprints will **continuously apply** from changes in the docker stack, newt restarting, or when viewing the resource in the dashboard.
+</Note>
+
 ### Enabling Docker Socket Access
 
 To use Docker labels, enable the Docker socket when running Newt:
@@ -192,6 +196,10 @@ DOCKER_SOCKET=/var/run/docker.sock
 ```
 
 ### Docker Compose Example
+
+<Note>
+The compose file will be the source of truth, any edits through the resources dashboard will be **overwritten** by the blueprint labels defined in the compose stack.
+</Note>
 
 ```yaml
 services:


### PR DESCRIPTION
Add blueprint docs clarifying docker label behavior.

Discussed in https://github.com/orgs/fosrl/discussions/1925#discussioncomment-15087772

> Blueprints applies can be triggered from a change in the docker stack,
from the newt restarting, or from visiting the resource in the
dashboard. This is because when you visit the resource it tries to sync
with the docker container.

## Screenshots

Dark Mode

<img width="1077" height="1037" alt="image" src="https://github.com/user-attachments/assets/12023a3e-12ed-499d-a670-3245c675db93" />

Light Mode

<img width="1107" height="1034" alt="image" src="https://github.com/user-attachments/assets/09361d1e-41aa-49da-b6d4-4e03678385ee" />
