### PR TITLE
Fix port number for olm client

### DIFF
--- a/manage/resources/client-resources.mdx
+++ b/manage/resources/client-resources.mdx
@@ -65,7 +65,7 @@ Here's how to set up SSH access to your server when connected with a client:
   When connected with a Olm client, you can SSH to your server using `<site-address>:2022`.
 
 ```bash
-ssh user@100.90.128.0 -p 22
+ssh user@100.90.128.0 -p 2022
 ```
 <Note>
 When accessing a site resource, you use the IP of the site found in the dashboard and the local port you configured for the resource.


### PR DESCRIPTION
Screenshot and text are referring to port number 2022 but command line is using port 22.