### PR TITLE
docs: Add missing cap_add configuration to Olm Docker Compose example

### DIFF
--- a/manage/clients/install-client.mdx
+++ b/manage/clients/install-client.mdx
@@ -190,6 +190,8 @@ services:
         container_name: olm
         restart: unless-stopped
         network_mode: host
+         cap_add:
+             - NET_ADMIN
         devices:
             - /dev/net/tun:/dev/net/tun
         environment:
@@ -207,6 +209,8 @@ services:
         container_name: olm
         restart: unless-stopped
         network_mode: host
+         cap_add:
+             - NET_ADMIN
         devices:
             - /dev/net/tun:/dev/net/tun
         command:


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited, perpetual license to use, modify, and redistribute these contributions under any terms they choose, including both the AGPLv3 and the Fossorial Commercial license terms. I represent that I have the right to grant this license for all contributed content.

## Description

The current Docker Compose example in the Olm installation documentation is missing the `cap_add: NET_ADMIN` capability, which causes the container to fail with "operation not permitted" when attempting to create the TUN device.

## Changes Made

- Added `cap_add: - NET_ADMIN` to both Docker Compose examples (environment variables and CLI args)
- This capability is required for WireGuard/TUN interface creation alongside the existing `devices` configuration

## Testing

Confirmed this resolves the "Failed to create TUN device: operation not permitted" error when running Olm in Docker.

## Related Issue

This addresses a common deployment blocker where the container lacks necessary Linux capabilities for network interface management.
