### PR TITLE
fix: extra space before  cap_add removed.

### DIFF
--- a/manage/clients/install-client.mdx
+++ b/manage/clients/install-client.mdx
@@ -222,6 +222,7 @@ services:
 **Docker Configuration Notes:**
 
 - `network_mode: host` brings the olm network interface to the host system, allowing the WireGuard tunnel to function properly
+- `cap_add: - NET_ADMIN` is required to grant the container permission to manage network interfaces
 - `devices: - /dev/net/tun:/dev/net/tun` is required to give the container access to the TUN device for creating WireGuard interfaces
 
 ### Windows Service


### PR DESCRIPTION
Apologies, just realised that I had added an extra space in old docker compose before `cap_add:`

Also, added explanation why this is required. 