### PR TITLE
Updated blueprint rules configuration to include priority.

### DIFF
--- a/manage/blueprints.mdx
+++ b/manage/blueprints.mdx
@@ -454,6 +454,13 @@ public-resources:
 | `action` | string | Yes | Rule action (`allow`, `deny`, or `pass`) | - |
 | `match` | string | Yes | Match type (`cidr`, `path`, `ip`, or `country`) | - |
 | `value` | string | Yes | Value to match against | Format depends on match type. For `country` match, use `ALL` to match all countries |
+| `priority` | number | No | Processing priority of the rule. | If not set, the priority is auto-assigned sequentially based on the rule order. |
+
+<Note>
+If no priority is defined, it is auto-assigned sequentially starting at 1 based on the rule order.
+Each rule consumes one priority slot, including rules with manually assigned priorities.
+Manual and auto-assigned priorities must be unique.
+</Note>
 
 ### Private Resources
 


### PR DESCRIPTION
Hello,

this PR is based on the changes made in the fosrl/pangolin repository:
https://github.com/fosrl/pangolin/pull/2209

If the PR for the main repository is not applicable, then this one is also not necessary. I just thought it would be good to have both open at the same time for discussion. I tried to explain the logic behind how priorities get auto-assigned currently (based on index of the rule) and how both those auto-assigned values and manual defined values must be unique. 