### PR TITLE
enhance(enterprise): Consistent naming scheme and update quick install

### DIFF
--- a/about/how-pangolin-works.mdx
+++ b/about/how-pangolin-works.mdx
@@ -72,7 +72,7 @@ Clients are available for Mac, Windows, and Linux. They work transparently with 
 
 ### Remote Nodes
 
-Remote nodes are self-hosted Pangolin servers that you control while using Pangolin Cloud or enterprise for management and coordination. You maintain complete control over your infrastructure and data flow, while the cloud handles the control plane, DNS, certificate management, and backups.
+Remote nodes are self-hosted Pangolin servers that you control while using Pangolin Cloud or [Enterprise Edition](/self-host/enterprise-edition) for management and coordination. You maintain complete control over your infrastructure and data flow, while the cloud handles the control plane, DNS, certificate management, and backups.
 
 You can deploy multiple remote nodes for high availability and automatic failover. If your nodes become unavailable, traffic can optionally fail over to cloud infrastructure until you restore service.
 

--- a/manage/access-control/approvals.mdx
+++ b/manage/access-control/approvals.mdx
@@ -4,7 +4,7 @@ description: "Only allow trusted devices to connect to an organization"
 ---
 
 <Note>
-	Only available in Pangolin Cloud and Enterprise.
+	Only available in Pangolin Cloud and [Enterprise Edition](/self-host/enterprise-edition).
 </Note>
 
 By default, any client configured with valid credentials can connect to an organization. To enhance security, you can enable device approvals, which require each new device to be manually approved by an administrator before it can connect.

--- a/manage/access-control/mfa.mdx
+++ b/manage/access-control/mfa.mdx
@@ -19,7 +19,7 @@ Pangolin supports two‑factor authentication (2FA) for Pangolin user accounts.
 ### Enforcement
 
 <Note>
-Two‑factor enforcement (requiring 2FA at login) is available in Enterprise Edition only.
+Two‑factor enforcement (requiring 2FA at login) is available in [Enterprise Edition](/self-host/enterprise-edition) only.
 </Note>
 
 To enable enforcement, go to Organization Settings and toggle 2FA enforcement in the Security section.

--- a/manage/access-control/password-rotation.mdx
+++ b/manage/access-control/password-rotation.mdx
@@ -8,7 +8,7 @@ By default, Pangolin does not require passwords to be rotated on a regular basis
 ### Configuration
 
 <Note>
-Password expiry and rotation is an Enterprise Edition only feature.
+Password expiry and rotation is an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 To enable password rotation, go to Organization Settings and select a maximum password age in the Security section. After the configured period expires, users will be prompted to change their password when accessing the organization or its resources.
@@ -16,4 +16,3 @@ To enable password rotation, go to Organization Settings and select a maximum pa
 - Password rotation is enforced on a per‑organization basis.
 - Password rotation only applies to internal Pangolin user accounts. This policy does not apply to accounts linked to an external identity provider.
 - Users who need to change their password will see a prompt directing them to update it before proceeding.
-

--- a/manage/access-control/session-length.mdx
+++ b/manage/access-control/session-length.mdx
@@ -10,7 +10,7 @@ However, you can require users to log in at regular intervals by enforcing maxim
 ### Configuration
 
 <Note>
-Session length enforcement is an Enterprise Edition only feature.
+Session length enforcement is an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 To enable session length enforcement, go to Organization Settings and set a maximum session length in the Security section. After this amount of time, users will be prompted to log back in to acquire a fresh session.
@@ -18,4 +18,3 @@ To enable session length enforcement, go to Organization Settings and set a maxi
 - Session length enforcement is configured per organization.
 - Session length enforcement applies to both internal Pangolin users and users linked to external identity providers.
 - Users whose session has expired will see a prompt directing them to log in again before proceeding.
-

--- a/manage/analytics/access.mdx
+++ b/manage/analytics/access.mdx
@@ -6,7 +6,7 @@ description: "Access logs are a record of each access attempt to a Pangolin reso
 Access logs provide detailed information about each access attempt made to your Pangolin resources. These logs help you monitor and analyze user activity each time they attempt to authenticate.
 
 <Note>
-Access logs is an Enterprise Edition only feature.
+Access logs are an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 ## What are Access Logs?

--- a/manage/analytics/action.mdx
+++ b/manage/analytics/action.mdx
@@ -6,7 +6,7 @@ description: "Action logs are a record of each event taken by users in the Pango
 Action logs provide an audit trail of administrative actions and configuration changes made within your Pangolin organization. These logs help you track who made what changes and when.
 
 <Note>
-Action logs is an Enterprise Edition only feature.
+Action logs are an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 ## What are Action Logs?

--- a/manage/blueprints.mdx
+++ b/manage/blueprints.mdx
@@ -22,7 +22,7 @@ Pangolin supports two blueprint formats:
 2. **Docker Labels**: Configuration embedded in Docker Compose files
 
 <Note type="info">
-Some features in this documentation are marked with **(EE)**, indicating they are available only in the Enterprise Edition of Pangolin.
+Some features in this documentation are marked with **(EE)**, indicating they are available only in [Enterprise Edition](/self-host/enterprise-edition) of Pangolin.
 </Note>
 
 ## YAML Configuration Format
@@ -182,7 +182,7 @@ When using targets-only resources, the `name` and `protocol` fields are not requ
 ### Maintenance Page Configuration **(EE)**
 
 <Note type="warning">
-This is an Enterprise Edition (EE) feature only. It allows you to display a maintenance page for a public resource when it's under maintenance or when targets are unhealthy.
+This is an [Enterprise Edition](/self-host/enterprise-edition) (EE)-only feature. It allows you to display a maintenance page for a public resource when it's under maintenance or when targets are unhealthy.
 </Note>
 
 ```yaml
@@ -350,7 +350,7 @@ This will create a resource that looks like the following:
 | `headers` | array | No | Custom headers to add to requests | Each header requires `name` and `value` (min 1 char each) |
 | `rules` | array | No | Access control rules | See Rules section below |
 | `auth` | object | HTTP only | Authentication configuration | See Authentication section below |
-| `maintenance` | object | No | Maintenance page configuration **(EE)** | Enterprise Edition only. See Maintenance Configuration section below |
+| `maintenance` | object | No | Maintenance page configuration **(EE)** | [Enterprise Edition](/self-host/enterprise-edition) only. See Maintenance Configuration section below |
 | `targets` | array | Yes | Target endpoints for the resource | See Targets section below |
 
 ### Target Configuration
@@ -433,7 +433,7 @@ Not allowed on TCP/UDP resources.
 ### Maintenance Configuration **(EE)**
 
 <Note type="warning">
-This is an Enterprise Edition (EE) feature only. It allows you to display a maintenance page for a public resource.
+This is an [Enterprise Edition](/self-host/enterprise-edition) (EE)-only feature. It allows you to display a maintenance page for a public resource.
 </Note>
 
 The `maintenance` object can be added to any public resource to display a maintenance page to users:

--- a/manage/branding.mdx
+++ b/manage/branding.mdx
@@ -5,7 +5,7 @@ description: "Learn how to customize the look your Pangolin dashboard and login 
 ---
 
 <Note>
-Branding is only available in Enterprise Edition.
+Branding is only available in [Enterprise Edition](/self-host/enterprise-edition).
 </Note>
 
 Pangolin allows you to customize the appearance of your dashboard with your own branding, including colors, logos, and custom text for authentication pages. Branding is configured through the `privateConfig.yml` file.

--- a/manage/clients/credentials.mdx
+++ b/manage/clients/credentials.mdx
@@ -38,7 +38,7 @@ The endpoint is how the client knows which server to connect to. This is the ful
 ## Rotating and Regenerating Credentials
 
 <Note>
-This is an Enterprise Edition only feature.
+This is an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 Client credentials can be regenerated. Regenerating credentials will completely invalidate the previous ID and secret. Use this feature if you have lost the secret and need to reset the credentials, or if you wish to rotate credentials on a regular basis for extra security.

--- a/manage/clients/fingerprinting.mdx
+++ b/manage/clients/fingerprinting.mdx
@@ -27,7 +27,7 @@ The following device attributes are collected on each device when available:
 ## Available Posture Checks
 
 <Note>
-	Posture checks are only collected on Pangolin Cloud and Enterprise.
+	Posture checks are only collected on Pangolin Cloud and self-hosted [Enterprise Edition](/self-host/enterprise-edition).
 </Note>
 
 Posture checks are also collected on each platform; this is device state that

--- a/manage/domains.mdx
+++ b/manage/domains.mdx
@@ -26,7 +26,7 @@ More about self-hosted DNS and networking can be found in the [DNS & Networking 
 
 ### Domain Delegation (NS Records)
 
-<Note>Cloud & Enterprise Only</Note>
+<Note>Cloud & [Enterprise Edition](/self-host/enterprise-edition) Only</Note>
 
 Gives Pangolin full DNS control over your domain.
 
@@ -38,7 +38,7 @@ Domain delegation is ideal when you want Pangolin to manage your entire domain a
 
 ### Single Domain (CNAME Records)
 
-<Note>Cloud & Enterprise Only</Note>
+<Note>Cloud & [Enterprise Edition](/self-host/enterprise-edition) Only</Note>
 
 Single domain is limited to the exact domain you specify.
 

--- a/manage/identity-providers/add-an-idp.mdx
+++ b/manage/identity-providers/add-an-idp.mdx
@@ -33,7 +33,7 @@ Here is an example using Microsoft Azure Entra ID as SSO for Pangolin:
 Organization identity providers are configured per organization and only apply to that specific organization. Each org can have its own identity providers, allowing for authentication methods based on the organization's needs.
 
 <Note>
-	Available in Pangolin Cloud and Enterprise. Enterprise users must enable `use_org_only_idp` in the [private config file](/self-host/advanced/private-config-file#param-use-org-only-idp) `privateConfig.yml`.
+	Available in Pangolin Cloud and [Enterprise Edition](/self-host/enterprise-edition). For [Enterprise Edition](/self-host/enterprise-edition), you must enable `use_org_only_idp` in the [private config file](/self-host/advanced/private-config-file#param-use-org-only-idp) `privateConfig.yml`.
 </Note>
 
 ### Global Identity Providers
@@ -58,7 +58,7 @@ This can be used to connect to any external identity provider that supports the 
 ### Google
 
 <Note>
-Google IdP is only available in Pangolin Cloud or Pangolin Enterprise with org identity providers. See above to enable.
+Google IdP is only available in Pangolin Cloud or self-hosted [Enterprise Edition](/self-host/enterprise-edition) with organization identity providers. See above to enable.
 </Note>
 
 Easily set up Google Workspace authentication for your organization. Users can sign in with their Google accounts and access Pangolin resources using their existing Google credentials. Perfect for organizations already using Google Workspace for email, calendar, and other services.
@@ -66,7 +66,7 @@ Easily set up Google Workspace authentication for your organization. Users can s
 ### Azure Entra ID
 
 <Note>
-Azure Entra ID IdP is only available in Pangolin Cloud or Pangolin Enterprise with org identity providers. See above to enable.
+Azure Entra ID IdP is only available in Pangolin Cloud or self-hosted [Enterprise Edition](/self-host/enterprise-edition) with organization identity providers. See above to enable.
 </Note>
 
 Integrate with Microsoft's enterprise identity platform to allow users to authenticate using their Azure Active Directory accounts. Ideal for organizations using Microsoft 365 or other Azure services, providing seamless single sign-on across your Microsoft ecosystem.

--- a/manage/identity-providers/azure.mdx
+++ b/manage/identity-providers/azure.mdx
@@ -4,7 +4,7 @@ description: "Configure Azure Entra ID Single Sign-On"
 ---
 
 <Note>
-Azure SSO is only available on Pangolin Cloud and Enterprise deployments. In enterprise, you must enable `use_org_only_idp` in your [private config file](/self-host/advanced/private-config-file) `privateConfig.yml`.
+Azure SSO is only available on Pangolin Cloud and [Enterprise Edition](/self-host/enterprise-edition) deployments. In [Enterprise Edition](/self-host/enterprise-edition), you must enable `use_org_only_idp` in your [private config file](/self-host/advanced/private-config-file) `privateConfig.yml`.
 </Note>
 
 The following steps will integrate Microsoft SSO using the built in Azure Entra ID identity provider in Pangolin.

--- a/manage/identity-providers/google.mdx
+++ b/manage/identity-providers/google.mdx
@@ -4,7 +4,7 @@ description: "Configure Google Single Sign-On"
 ---
 
 <Note>
-Google SSO is only available on Pangolin Cloud and Enterprise deployments. In enterprise, you must enable `use_org_only_idp` in your [private config file](/self-host/advanced/private-config-file#param-use-org-only-idp) `privateConfig.yml`.
+Google SSO is only available on Pangolin Cloud and [Enterprise Edition](/self-host/enterprise-edition) deployments. In [Enterprise Edition](/self-host/enterprise-edition), you must enable `use_org_only_idp` in your [private config file](/self-host/advanced/private-config-file#param-use-org-only-idp) `privateConfig.yml`.
 </Note>
 
 The following steps will integrate Google SSO using the built in Google identity provider in Pangolin.

--- a/manage/remote-node/understanding-nodes.mdx
+++ b/manage/remote-node/understanding-nodes.mdx
@@ -4,10 +4,10 @@ description: "Control your own Pangolin node with cloud management"
 ---
 
 <Note>
-	Remote Nodes are available in Pangolin Enterprise and Pangolin Cloud.
+	Remote Nodes are available in Pangolin Cloud and self-hosted [Enterprise Edition](/self-host/enterprise-edition).
 </Note>
 
-Remote nodes, you run your own Pangolin node - your tunnels, SSL termination, and traffic all stay on your server and use your bandwidth. The difference is that management and monitoring are handled through our cloud or your central Pangolin Enterprise server. The node just handles terminating Wireguard tunnels, serving HTTP(S) traffic, and routing relayed client connections - it is essentially a remote networking hub.
+Remote nodes, you run your own Pangolin node - your tunnels, SSL termination, and traffic all stay on your server and use your bandwidth. The difference is that management and monitoring are handled through our cloud or your central self-hosted [Enterprise Edition](/self-host/enterprise-edition) server. The node just handles terminating Wireguard tunnels, serving HTTP(S) traffic, and routing relayed client connections - it is essentially a remote networking hub.
 
 Think of different nodes as the "front doors" to your applications - users connect to the closest one, and it securely routes their requests to your backend services.
 

--- a/manage/resources/public/maintenance.mdx
+++ b/manage/resources/public/maintenance.mdx
@@ -4,7 +4,7 @@ description: "Show a maintenance page to users when a resources is down for main
 ---
 
 <Note>
-Maintenance pages are only available in Enterprise Edition.
+Maintenance pages are only available in [Enterprise Edition](/self-host/enterprise-edition).
 </Note>
 
 Pangolin can display a customizable maintenance page to users when a resource is undergoing maintenance or when all targets are unhealthy. This ensures users are informed about the downtime and provides a better user experience.

--- a/manage/resources/public/targets.mdx
+++ b/manage/resources/public/targets.mdx
@@ -35,7 +35,7 @@ You can now configure targets across different sites for the same resource:
 ### Distributing Sites Load Across Servers
 
 <Note>
-This is an Enterprise Edition only feature.
+This is an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 This refers to having more than on Pangolin server node that a site can connect to. If one of the server nodes goes down, the site moves to another node. This has some implications for site-based load balancing, because DNS must can only route a FQDN to one Pangolin server node at a time.

--- a/manage/sites/credentials.mdx
+++ b/manage/sites/credentials.mdx
@@ -36,7 +36,7 @@ The endpoint is how the site knows which server to connect to. This is the fully
 ## Rotating and Regenerating Credentials
 
 <Note>
-This is an Enterprise Edition only feature.
+This is an [Enterprise Edition](/self-host/enterprise-edition)-only feature.
 </Note>
 
 Site credentials can be regenerated. Regenerating credentials will completely invalidate the previous ID and secret. Use this feature if you have lost the secret and need to reset the credentials, or if you wish to rotate credentials on a regular basis for extra security.

--- a/self-host/advanced/clustering.mdx
+++ b/self-host/advanced/clustering.mdx
@@ -3,7 +3,7 @@ title: "Clustering for High Availability"
 ---
 
 <Note>
-Clustering is only available in Enterprise Edition. [Please reach out to us to deploy](https://pangolin.net/talk-to-us).
+Clustering is only available in [Enterprise Edition](/self-host/enterprise-edition). [Please reach out to us to deploy](https://pangolin.net/talk-to-us).
 </Note>
 
 Deploy multiple Pangolin servers enterprise-grade high availability and performance in large deployments.
@@ -40,8 +40,6 @@ Each Pangolin instance runs alongside its own Gerbil tunnel manager, which handl
 
 ## Enterprise Support
 
-Clustered deployments require careful planning around database replication, Redis configuration, network topology, and monitoring. These advanced architectures are available as part of Pangolin's Enterprise Edition with dedicated support for design, deployment, and ongoing operations.
+Clustered deployments require careful planning around database replication, Redis configuration, network topology, and monitoring. These advanced architectures are available as part of Pangolin's [Enterprise Edition](/self-host/enterprise-edition) with dedicated support for design, deployment, and ongoing operations.
 
 For organizations interested in clustering for high availability or regional distribution, please [contact our enterprise team](https://pangolin.net/talk-to-us) to discuss your requirements and receive implementation guidance.
-
-

--- a/self-host/enterprise-edition.mdx
+++ b/self-host/enterprise-edition.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Enterprise Edition"
-description: "Learn about Pangolin Enterprise Edition features, licensing, and how to get started"
+description: "Learn about Enterprise Edition features, licensing, and how to get started"
 ---
 
 When self-hosting Pangolin, you can choose to run the **Community Edition** or the **Enterprise Edition**. Both editions provide the same core functionality, but the Enterprise Edition unlocks additional features for qualifying users.

--- a/self-host/quick-install.mdx
+++ b/self-host/quick-install.mdx
@@ -60,6 +60,7 @@ Before installing Pangolin, ensure you've set up DNS for your domain(s) and open
 <Step title="Configure basic settings">
   The installer will prompt you for essential configuration:
   
+  - **Edition**: Choose Community Edition or [Enterprise Edition](/self-host/enterprise-edition). Review the edition differences before continuing.
   - **Base Domain**: Enter your root domain without subdomains (e.g., `example.com`)
   - **Dashboard Domain**: Press Enter to accept the default `pangolin.example.com` or enter a custom domain
   - **Let's Encrypt Email**: Provide an email for SSL certificates and admin login

--- a/self-host/supporter-program.mdx
+++ b/self-host/supporter-program.mdx
@@ -6,7 +6,7 @@ description: "Support Pangolin development and remove UI elements with a support
 Pangolin self-hosted will always be free and open source, but maintaining the project takes time and resources. The supporter program helps fund ongoing development — including bug fixes, new features, and community support.
 
 <Note>
-	**Business & Enterprise Users:** For larger organizations or teams requiring advanced features, consider our self-serve enterprise license and Enterprise Edition. [Learn more](https://pangolin.net/pricing?hosting=self-host)
+	**Business & Enterprise Users:** For larger organizations or teams requiring advanced features, consider our self-serve enterprise license and [Enterprise Edition](/self-host/enterprise-edition). [Learn more](https://pangolin.net/pricing?hosting=self-host)
 </Note>
 
 ## Supporter Tiers


### PR DESCRIPTION
Standardize edition-gated terminology to Enterprise Edition across docs where feature availability is described.

Add links to /self-host/enterprise-edition so users can quickly understand edition differences before enabling gated features or selecting an installer edition.