### PR TITLE
enhance(DNS-01): add a solution for provider firewall

### DIFF
--- a/self-host/advanced/wild-card-domains.mdx
+++ b/self-host/advanced/wild-card-domains.mdx
@@ -255,12 +255,8 @@ Traefik supports most DNS providers. You can find a full list of supported provi
   - Check API token permissions and scope
   - Ensure DNS propagation has completed
   - Review provider-specific configuration
+  - If your DNS provider has a firewall in place, ensure it allows incoming DNS traffic (typically UDP on port **53**). Adding an ingress rule to permit such traffic may help resolve the issue, especially if the firewall is stateless.
 
-  <Info>
-  **Known issue with Netcup**: DNS-01 can fail on Netcup due to how their provider firewall handles UDP. DNS replies may be treated as inbound traffic **from source port `53`** and get dropped.
-
-  **Workaround**: Allow **ingress UDP** with **source port `53`** (to your server's UDP ports, or `ANY`). Repeat this for other UDP-based services if needed.
-  </Info>
 </Accordion>
 
 <Accordion title="Old certificates still being used">


### PR DESCRIPTION
Providers like NetCup have a stateless firewall meaning related or established traffic are not permitted by default user must explicitly allow src port 53 to complete the challenge