### PR TITLE
Fix broken anchor links in documentation across multiple files

### DIFF
--- a/manage/access-control/login-page.mdx
+++ b/manage/access-control/login-page.mdx
@@ -39,7 +39,7 @@ Custom organization authentication pages let you serve the login page at your ow
 3. Save your changes
 
 <Note>
-You need to add a custom domain to your organization first. Free domains (`*.tunneled.to`, `*.hostlocal.app`, etc.) cannot be used for auth pages. [Learn how to add domains](/manage/domains#adding-domains)
+You need to add a custom domain to your organization first. Free domains (`*.tunneled.to`, `*.hostlocal.app`, etc.) cannot be used for auth pages. [Learn how to add domains](/manage/domains)
 </Note>
 
 <Frame>

--- a/manage/access-control/rules.mdx
+++ b/manage/access-control/rules.mdx
@@ -71,13 +71,13 @@ We use a IP database to geolocate the IP address but this is not always accurate
 
 Select the "ALL" option to match all countries for allowing or denying access.
 
-To enable geoblocking, follow this guide to set up the geolocation database: [Geoblocking Guide](/self-host/advanced/enable-geoblocking#enable-geo-blocking).
+To enable geoblocking, follow this guide to set up the geolocation database: [Geoblocking Guide](/self-host/advanced/enable-geoblocking).
 
 ### Region
 
 Region match rules allow you to specify allowed or denied regions for requests based on their IP address. This is useful for geo-restrictions or compliance with regional regulations. Regions are made up of a list of countries in that region (e.g. "EU" includes France, Germany, etc.) so this is a more broad match than country.
 
-To enable follow the above guide to set up the geolocation database: [Geoblocking Guide](/self-host/advanced/enable-geoblocking#enable-geo-blocking).
+To enable follow the above guide to set up the geolocation database: [Geoblocking Guide](/self-host/advanced/enable-geoblocking).
 
 ### CIDR
 
@@ -102,7 +102,7 @@ Pretty simple: you can match on simply an IP address like your home IP to bypass
 
 ASN (Autonomous System Number) match rules allow you to specify allowed or denied ASNs for requests based on their IP address. This is useful for blocking or allowing traffic from specific ISPs or organizations.
 
-To enable ASN blocking, follow this guide to set up the ASN database: [ASN Blocking Guide](/self-host/advanced/enable-asnblocking#enable-asn-blocking).
+To enable ASN blocking, follow this guide to set up the ASN database: [ASN Blocking Guide](/self-host/advanced/enable-asnblocking).
 
 **Examples:**
 

--- a/manage/ssh.mdx
+++ b/manage/ssh.mdx
@@ -27,10 +27,10 @@ Pangolin includes a built-in SSH client so you can connect to remote servers and
 You can SSH into any Pangolin site or private resource. Two components handle SSH on the server side:
 
 <CardGroup cols={2}>
-  <Card title="Newt Host" icon="plug" href="#configure-ssh-on-the-newt-host">
+  <Card title="Newt Host" icon="plug" href="#option-1-newt-as-the-auth-daemon-same-host">
     Runs as a daemon and handles SSH for the host it runs on. Use this when the machine you want to SSH into is the same server running Newt.
   </Card>
-  <Card title="Hosts Behind Newt" icon="server" href="#configure-ssh-on-hosts-behind-newt">
+  <Card title="Hosts Behind Newt" icon="server" href="#option-2-external-auth-daemon-ssh-on-another-server-that-doesnt-run-newt">
     Handles SSH for other servers on the same network. Run the auth daemon on each target host; Newt on a bastion proxies connections to them.
   </Card>
 </CardGroup>
@@ -85,7 +85,7 @@ If TCP 22 is not allowed in the resource’s port restrictions, users will not b
   <img src="/images/auth-daemon-location.png" alt="Pangolin Dashboard"/>
 </Frame>
 
-After the resource exists and access is granted, proceed with [Option 1](#option-1-newt-as-the-auth-daemon-same-host) or [Option 2](#option-2-external-auth-daemon-different-servers) below.
+After the resource exists and access is granted, proceed with [Option 1](#option-1-newt-as-the-auth-daemon-same-host) or [Option 2](#option-2-external-auth-daemon-ssh-on-another-server-that-doesnt-run-newt) below.
 
 ## Option 1: Newt as the auth daemon (same host)
 

--- a/self-host/community-guides/geolite2automation.mdx
+++ b/self-host/community-guides/geolite2automation.mdx
@@ -21,8 +21,8 @@ Maxmind's service is free of charge for development, personal or community use. 
 1. **[Requirements](#1-requirements)**
 2. **[Maxmind Account](#2-maxmind-account)**
 3. **[API key creation](#3-api-key-creation)**
-4. **[Modification of Pangolin's `docker-compose.yml`](#4-modification-of-pangolin’s-docker-compose-yml)**
-5. **[Modification of Pangolin's `config.yml`](#5-modification-of-pangolin’s-config-yml)**
+4. **[Modification of Pangolin's `docker-compose.yml`](#4-modification-of-pangolins-docker-compose-yml)**
+5. **[Modification of Pangolin's `config.yml`](#5-modification-of-pangolins-config-yml)**
 
 ## 1. Requirements
 * A Maxmind account for API access


### PR DESCRIPTION
## Command

``` sh
mint broken-links --check-anchors --check-redirects --check-snippets

found 9 broken links in 4 files

manage/access-control/login-page.mdx
 ⎿  /manage/domains#adding-domains

manage/access-control/rules.mdx
 ⎿  /self-host/advanced/enable-geoblocking#enable-geo-blocking
 ⎿  /self-host/advanced/enable-geoblocking#enable-geo-blocking
 ⎿  /self-host/advanced/enable-asnblocking#enable-asn-blocking

manage/ssh.mdx
 ⎿  #configure-ssh-on-the-newt-host
 ⎿  #configure-ssh-on-hosts-behind-newt
 ⎿  #option-2-external-auth-daemon-different-servers

self-host/community-guides/geolite2automation.mdx
 ⎿  #4-modification-of-pangolin’s-docker-compose-yml
 ⎿  #5-modification-of-pangolin’s-config-yml
```

---

- Fixed domains link anchor in login-page.mdx
- Fixed geoblocking link anchors in rules.mdx (2 instances)
- Fixed ASN blocking link anchor in rules.mdx
- Fixed SSH section card href anchors in ssh.mdx
- Fixed option 2 internal link anchor in ssh.mdx
- Fixed table of contents anchors in geolite2automation.mdx (removed apostrophes)

Resolves 9 broken links across 4 files

---

## Description (Copilot generated)

This pull request updates several documentation files to improve clarity and consistency, primarily by fixing internal links and section references. The changes ensure that documentation navigation is more reliable and that section anchors accurately reflect their targets.

**Documentation Link and Anchor Updates:**

* Updated links in `manage/access-control/rules.mdx` to remove unnecessary section anchors, ensuring that references to the Geoblocking and ASN Blocking guides point to the correct top-level sections. [[1]](diffhunk://#diff-cc8e03909c85da01a1bc20c95ec11eb296b4b662bd3e07037e59864341bc965dL74-R80) [[2]](diffhunk://#diff-cc8e03909c85da01a1bc20c95ec11eb296b4b662bd3e07037e59864341bc965dL105-R105)
* Updated the domain addition link in `manage/access-control/login-page.mdx` to remove the section anchor, pointing to the main domains documentation.

**Section and Anchor Consistency:**

* Corrected anchor references and section titles in `manage/ssh.mdx` to match the actual section IDs, improving navigation for SSH setup options. [[1]](diffhunk://#diff-b2dc80e490e2c6d01e099529cc5d7133e0fdb0b5510ac2fe26ae17822c8e5e53L30-R33) [[2]](diffhunk://#diff-b2dc80e490e2c6d01e099529cc5d7133e0fdb0b5510ac2fe26ae17822c8e5e53L88-R88)
* Fixed anchor formatting in the table of contents in `self-host/community-guides/geolite2automation.mdx` to remove smart quotes and ensure anchor links work as expected.