### PR TITLE
docs: add missing alt attributes to documentation images

### DIFF
--- a/manage/access-control/approvals.mdx
+++ b/manage/access-control/approvals.mdx
@@ -18,13 +18,13 @@ By default, any client configured with valid credentials can connect to an organ
 When device approvals are enabled, the first time a user connects a new device to the organization, the device will be marked as "Pending Approval." An administrator must then review and approve the device in the management console before it can access organization resources.
 
 <Frame>
-  <img src="/images/device_waiting_approval.png" />
+  <img src="/images/device_waiting_approval.png" alt="Device marked pending approval in the Pangolin dashboard" />
 </Frame>
 
 All approvals can also be managed from a central page as they stream in to allow admins to approve or deny devices quickly.
 
 <Frame>
-  <img src="/images/approvals_page.png" />
+  <img src="/images/approvals_page.png" alt="Approvals page listing pending devices in the Pangolin dashboard" />
 </Frame>
 
 ## Enabling Device Approvals

--- a/manage/access-control/create-user.mdx
+++ b/manage/access-control/create-user.mdx
@@ -18,7 +18,7 @@ Because the global user exists and a per‑organization user exists, a user invi
 When removing a user from an organization, their account still exists. To completely delete their account, visit the server admin panel as the server admin and delete the global user in the users table.
 
 <Frame>
-  <img src="/images/users-table.png" centered/>
+  <img src="/images/users-table.png" alt="Users table in the Pangolin dashboard" centered/>
 </Frame>
 
 ### Internal Users

--- a/manage/access-control/links.mdx
+++ b/manage/access-control/links.mdx
@@ -45,7 +45,7 @@ This is why the two URLs often look different:
 - The **Access Token Usage** examples use the resource URL directly.
 
 <Frame>
-  <img src="/images/links-access-token-usage.png" />
+  <img src="/images/links-access-token-usage.png" alt="Access token usage examples for a shareable link" />
 </Frame>
 
 ### Query Parameter

--- a/manage/access-control/login-page.mdx
+++ b/manage/access-control/login-page.mdx
@@ -29,7 +29,7 @@ Custom organization authentication pages let you serve the login page at your ow
 - Direct access to the Pangolin management dashboard
 
 <Frame>
-  <img src="/images/org-auth-page.png" />
+  <img src="/images/org-auth-page.png" alt="Organization login page with multiple login methods" />
 </Frame>
 
 ## Configuration
@@ -43,5 +43,5 @@ You need to add a custom domain to your organization first. Free domains (`*.tun
 </Note>
 
 <Frame>
-  <img src="/images/set-org-auth-page-domain.png" />
+  <img src="/images/set-org-auth-page-domain.png" alt="Domain picker for the auth page in Pangolin settings" />
 </Frame>

--- a/manage/analytics/access.mdx
+++ b/manage/analytics/access.mdx
@@ -26,7 +26,7 @@ Authentication logs capture authentication events when users or API keys attempt
 - Analyzing user agent and device information
 
 <Frame>
-  <img src="/images/access_logs.png" centered/>
+  <img src="/images/access_logs.png" alt="Authentication logs table in the Pangolin dashboard" centered/>
 </Frame>
 
 <Tip>Make sure to enable authentication logs in the org settings</Tip>

--- a/manage/analytics/action.mdx
+++ b/manage/analytics/action.mdx
@@ -26,7 +26,7 @@ Admin Action logs capture administrative events and configuration changes perfor
 - Meeting security and compliance requirements
 
 <Frame>
-  <img src="/images/action_logs.png" centered/>
+  <img src="/images/action_logs.png" alt="Admin action logs table in the Pangolin dashboard" centered/>
 </Frame>
 
 <Tip>Make sure to enable access logs in the org settings</Tip>

--- a/manage/analytics/request.mdx
+++ b/manage/analytics/request.mdx
@@ -23,7 +23,7 @@ HTTPS Request logs capture every HTTPS request that passes through a reverse pro
 - Troubleshooting connectivity and routing issues
 
 <Frame>
-  <img src="/images/request_logs.png" centered/>
+  <img src="/images/request_logs.png" alt="HTTPS request logs table in the Pangolin dashboard" centered/>
 </Frame>
 
 ## HTTPS Request Log Fields

--- a/manage/analytics/streaming.mdx
+++ b/manage/analytics/streaming.mdx
@@ -22,7 +22,7 @@ Open **Organization → Logs & Analytics → Streaming** to add destinations and
 You choose which categories each destination receives. Only log types enabled for your organization can be streamed.
 
 <Frame>
-  <img src="/images/streaming-log-types.png" centered />
+  <img src="/images/streaming-log-types.png" alt="Log type selection for a streaming destination" centered />
 </Frame>
 
 ## Destination types
@@ -30,7 +30,7 @@ You choose which categories each destination receives. Only log types enabled fo
 Each destination type has its own configuration and payload behavior. Select **Add destination** and pick a delivery method.
 
 <Frame>
-  <img src="/images/streaming-add-destination.png" centered />
+  <img src="/images/streaming-add-destination.png" alt="Add destination dialog in the Pangolin dashboard" centered />
 </Frame>
 
 <CardGroup cols={2}>

--- a/manage/analytics/streaming/http.mdx
+++ b/manage/analytics/streaming/http.mdx
@@ -36,7 +36,7 @@ On the **Settings** tab, set a display name, the endpoint URL, and authenticatio
 | Custom header | A single header name and value (for example an API key header) |
 
 <Frame>
-  <img src="/images/streaming-http-settings.png" centered />
+  <img src="/images/streaming-http-settings.png" alt="HTTP destination settings with URL and authentication options" centered />
 </Frame>
 
 All delivery uses **POST**. Requests time out after 30 seconds.
@@ -46,7 +46,7 @@ All delivery uses **POST**. Requests time out after 30 seconds.
 On the **Headers** tab, add optional static headers sent with every request, for example a vendor-specific API key or a non-default `Content-Type`. When you do not override it, Pangolin sends `Content-Type: application/json` (or `application/x-ndjson` when using the NDJSON payload format).
 
 <Frame>
-  <img src="/images/streaming-http-headers.png" centered />
+  <img src="/images/streaming-http-headers.png" alt="Headers tab for adding static HTTP headers" centered />
 </Frame>
 
 ## Default payload (template off)
@@ -83,7 +83,7 @@ Some columns are stored as JSON strings in the database (`headers`, `query`, and
 On the **Body** tab, enable **Custom body template** and provide a JSON template string. Pangolin performs simple placeholder substitution, **not** a full templating language like Handlebars.
 
 <Frame>
-  <img src="/images/streaming-http-body.png" centered />
+  <img src="/images/streaming-http-body.png" alt="Body tab with custom body template editor" centered />
 </Frame>
 
 ### Template variables

--- a/manage/analytics/streaming/s3.mdx
+++ b/manage/analytics/streaming/s3.mdx
@@ -38,7 +38,7 @@ Configure:
 Pangolin uses static access keys only. There is no IAM role, instance profile, or OIDC picker in the UI.
 
 <Frame>
-  <img src="/images/streaming-s3-settings.png" centered />
+  <img src="/images/streaming-s3-settings.png" alt="S3 destination settings with credentials, region, and bucket" centered />
 </Frame>
 
 Uploads time out after 60 seconds per object.
@@ -56,7 +56,7 @@ Uploads time out after 60 seconds per object.
 | **CSV** | RFC-4180 CSV with a header row; see [CSV format](#csv-format) |
 
 <Frame>
-  <img src="/images/streaming-s3-format.png" centered />
+  <img src="/images/streaming-s3-format.png" alt="Format tab with file format and gzip options" centered />
 </Frame>
 
 ## Logs tab
@@ -64,7 +64,7 @@ Uploads time out after 60 seconds per object.
 Choose which log categories are uploaded. Each enabled type is written to its own key prefix (`request/`, `action/`, etc.). Only log types enabled for your organization can be streamed.
 
 <Frame>
-  <img src="/images/streaming-s3-logs.png" centered />
+  <img src="/images/streaming-s3-logs.png" alt="Logs tab for selecting streamed log types" centered />
 </Frame>
 
 ## Object key layout

--- a/manage/blueprints.mdx
+++ b/manage/blueprints.mdx
@@ -68,7 +68,7 @@ Use container labels when the resource definition should live inside your Compos
   Paste YAML into **Settings > Blueprints** in the Pangolin dashboard.
 
   <Frame>
-    <img src="/images/create_blueprint.png" width="400" centered/>
+    <img src="/images/create_blueprint.png" alt="Blueprint creation page in the Pangolin dashboard" width="400" centered/>
   </Frame>
 </Card>
 

--- a/manage/identity-providers/add-an-idp.mdx
+++ b/manage/identity-providers/add-an-idp.mdx
@@ -22,7 +22,7 @@ Here is an example using Microsoft Azure Entra ID as SSO for Pangolin:
 </Note>
 
 <Frame>
-  <img src="/images/create-idp.png" />
+  <img src="/images/create-idp.png" alt="Identity provider creation form in the Pangolin dashboard" />
 </Frame>
 
 ## Identity Provider Types

--- a/manage/identity-providers/auto-provisioning.mdx
+++ b/manage/identity-providers/auto-provisioning.mdx
@@ -16,7 +16,7 @@ You will be able to programmatically decide the roles and organizations for new 
 Toggle the "Auth Provision Users" switch when creating or editing an identity provider.
 
 <Frame>
-  <img src="/images/mapping-builder.png" />
+  <img src="/images/mapping-builder.png" alt="Auto provision users setting in the Pangolin dashboard" />
 </Frame>
 
 ## What if Auto Provisioning is Disabled?
@@ -24,7 +24,7 @@ Toggle the "Auth Provision Users" switch when creating or editing an identity pr
 If auto provision is disabled, organization admins will need to manually create the user accounts and select the role for each user. When creating a user, you can select the identity provider that the user will be associated with. A user will not be able to log in using the identity provider if a user is not pre-provisioned in the system.
 
 <Frame>
-  <img src="/images/create-idp-user.png" />
+  <img src="/images/create-idp-user.png" alt="Creating an identity provider user in the Pangolin dashboard" />
 </Frame>
 
 ## Role Mappings
@@ -40,7 +40,7 @@ When you configure role mappings in auto provisioning settings, you use one of t
 Fixed roles is the simplest option. Every user who signs in through the identity provider receives the same set of roles. The roles you select must already exist in Pangolin, and you must choose them by their exact names in that organization. Use this when you do not need dynamic mapping and a single role assignment for everyone is enough. You can still change roles on individual users after they have been auto-provisioned. This is the easiest way to get started.
 
 <Frame>
-  <img src="/images/fixed-roles.png" />
+  <img src="/images/fixed-roles.png" alt="Fixed roles mapping option in the Pangolin dashboard" />
 </Frame>
 
 ### Role Mapping: Mapping Builder
@@ -50,7 +50,7 @@ The mapping builder lets you map roles from your identity provider to Pangolin r
 First, choose the claim in the OIDC token where roles or groups are provided such as `groups`. Then define a one-to-one mapping for each role: on one side, the role or group ID from the identity provider; on the other, the Pangolin role name that already exists in the organization. The Pangolin side must match that role’s name exactly (same spelling, spacing, and casing).
 
 <Frame>
-  <img src="/images/mapping-builder.png" />
+  <img src="/images/mapping-builder.png" alt="Role mapping builder in the Pangolin dashboard" />
 </Frame>
 
 ### Role Mapping: Raw Expression
@@ -63,7 +63,7 @@ The expression is evaluated against the token from the identity provider on each
 - If no matching role is found for the resolved names, the user is not added to the organization.
 
 <Frame>
-  <img src="/images/raw-expression.png" />
+  <img src="/images/raw-expression.png" alt="Raw expression role mapping in the Pangolin dashboard" />
 </Frame>
 
 #### Raw Expression Example: JMESPath role selection

--- a/manage/identity-providers/azure.mdx
+++ b/manage/identity-providers/azure.mdx
@@ -42,7 +42,7 @@ We will revisit the **Authorised redirect URIs** field later, as we do not have 
 In Pangolin, go to "Identity Providers" and click "Add Identity Provider". Select the Azure Entra ID provider option.
 
 <Frame>
-  <img src="/images/create-azure-idp.png" />
+  <img src="/images/create-azure-idp.png" alt="Azure Entra ID identity provider setup in the Pangolin dashboard" />
 </Frame>
 
 In the OAuth2/OIDC Configuration, you'll need the following fields:

--- a/manage/identity-providers/google.mdx
+++ b/manage/identity-providers/google.mdx
@@ -51,7 +51,7 @@ After hitting "Create", you will be able to see the "Client ID" and "Client secr
 In Pangolin, go to "Identity Providers" and click "Add Identity Provider". Select the Google provider option.
 
 <Frame>
-  <img src="/images/create-google-idp.png" />
+  <img src="/images/create-google-idp.png" alt="Google identity provider setup in the Pangolin dashboard" />
 </Frame>
 
 In the "Google Configuration", you'll need the following fields:

--- a/manage/identity-providers/openid-connect.mdx
+++ b/manage/identity-providers/openid-connect.mdx
@@ -16,7 +16,7 @@ This identity provider follows the OpenID Connect protocol. This means that it c
 In Pangolin, go to "Identity Providers" and click "Add Identity Provider". Select the OAuth2/OIDC provider option.
 
 <Frame>
-  <img src="/images/create-oidc-idp.png" />
+  <img src="/images/create-oidc-idp.png" alt="Pangolin dashboard form for adding an OAuth2/OIDC identity provider" />
 </Frame>
 
 In the OAuth2/OIDC Configuration, you'll need the following fields:

--- a/manage/remote-node/backhaul.mdx
+++ b/manage/remote-node/backhaul.mdx
@@ -194,7 +194,7 @@ This section uses AWS as an example, but the same steps apply to any VPC-style n
 	The node is acting as a concentrator for the whole network, not just serving its own ports, so its security group must accept all traffic from the VPC's CIDR. Otherwise the security group blocks the inbound traffic it's meant to forward.
 
 	<Frame>
-		<img src="/images/security_group_inbound_to_node.png" />
+		<img src="/images/security_group_inbound_to_node.png" alt="AWS security group inbound rule allowing all VPC traffic" />
 	</Frame>
 </Step>
 
@@ -202,7 +202,7 @@ This section uses AWS as an example, but the same steps apply to any VPC-style n
 	Add a route in the VPC's route table for the WireGuard overlay subnet assigned to your node (shown as the node's **Address** on its page in the [Pangolin dashboard](https://app.pangolin.net)), targeting the node's instance or network interface. This tells the rest of the VPC to send anything destined for the Pangolin overlay — other sites and clients — to the node.
 
 	<Frame>
-		<img src="/images/subnet_in_route_table.png" />
+		<img src="/images/subnet_in_route_table.png" alt="AWS route table entry routing the overlay subnet to the node" />
 	</Frame>
 </Step>
 
@@ -210,11 +210,11 @@ This section uses AWS as an example, but the same steps apply to any VPC-style n
 	By default, AWS drops any packet where an instance isn't the source or destination, which would silently break a node that's forwarding traffic on behalf of others. Disable the source/destination check on the node's instance so it's allowed to route traffic that isn't addressed to itself.
 
 	<Frame>
-		<img src="/images/source_destination_check_menu.png" />
+		<img src="/images/source_destination_check_menu.png" alt="AWS instance menu option to change source/destination check" />
 	</Frame>
 
 	<Frame>
-		<img src="/images/source_destination_check_box.png" />
+		<img src="/images/source_destination_check_box.png" alt="AWS dialog checkbox disabling the source/destination check" />
 	</Frame>
 </Step>
 
@@ -224,7 +224,7 @@ This section uses AWS as an example, but the same steps apply to any VPC-style n
 	You can also set **Preference Labels** on the node and apply matching labels to sites, which enforces that those sites connect through this remote node specifically. This is useful once you have more than one node or point of presence and want particular sites to always backhaul through this one.
 
 	<Frame>
-		<img src="/images/subnet_programmed_on_node.png" />
+		<img src="/images/subnet_programmed_on_node.png" alt="Pangolin dashboard remote subnets setting with VPC CIDR added" />
 	</Frame>
 </Step>
 </Steps>

--- a/manage/remote-node/understanding-nodes.mdx
+++ b/manage/remote-node/understanding-nodes.mdx
@@ -29,7 +29,7 @@ Think of different nodes as the "front doors" to your applications - users conne
 - **Failover**: If you have multiple nodes, the control plane will failover between them. If one node becomes unavailable, traffic can optionally fail over to our cloud infrastructure or other nodes until you restore service.
 
 <Frame>
-  <img src="/images/ha.png" width="400" centered/>
+  <img src="/images/ha.png" alt="Diagram of high availability failover across remote nodes" width="400" centered/>
 </Frame>
 
 ## Some Benefits

--- a/manage/sites/install-site.mdx
+++ b/manage/sites/install-site.mdx
@@ -291,13 +291,13 @@ Download the correct version of the router app for your device from the [GitHub 
 To install the router app, log into your Advantech router and navigate to the Router Apps section. Upload the downloaded `.tgz` file and follow the prompts to install. 
 
 <Frame caption="Screenshot of installing the router app on an Advantech router UI">
-  <img src="/images/advantech_router_app_install.png" width="400" centered/>
+  <img src="/images/advantech_router_app_install.png" alt="Advantech router UI showing Newt router app installation" width="400" centered/>
 </Frame>
 
 After installation, click on the router app link at the top of the page to configure the app with your Newt credentials from Pangolin. Once you have entered the credentials, save and start the app. The router will now be connected to your Pangolin site and you can manage it like any other Newt site in the dashboard.
 
 <Frame caption="Screenshot of configuring the router app on an Advantech router UI">
-  <img src="/images/advantech_router_app_configure.png" width="400" centered/>
+  <img src="/images/advantech_router_app_configure.png" alt="Advantech router UI showing Newt credential configuration" width="400" centered/>
 </Frame>
 
 A complete config file is located at `/etc/newt/settings` on the router. You can edit this file directly to change credentials or add additional configuration options. After making changes, restart the router app to apply the new configuration. An example settings file can be found at: https://github.com/fosrl/newt/blob/main/packages/advantech/merge/etc/defaults

--- a/self-host/advanced/cloudflare-proxy.mdx
+++ b/self-host/advanced/cloudflare-proxy.mdx
@@ -143,5 +143,5 @@ After making these changes, restart both Traefik and Pangolin for the configurat
 If websockets are not connecting like from newt or clients, ensure that websockets are enabled in Cloudflare:
 
 <Frame>
-  <img src="/images/cf_websocket_box.png" width="600" centered/>
+  <img src="/images/cf_websocket_box.png" alt="Cloudflare dashboard WebSockets setting toggled on" width="600" centered/>
 </Frame>


### PR DESCRIPTION
## Summary

Part of #116.

Adds `alt` attributes to all images flagged by `mint a11y`, so screen readers can describe the documentation screenshots.

**Scope note:** the issue originally listed 26 images in 16 files. The docs have grown since it was filed, so this PR covers the current state: **36 images across 20 files** (new pages like `manage/analytics/streaming/http.mdx`, `manage/remote-node/backhaul.mdx`, and `manage/sites/install-site.mdx` are included).

## Convention used

- Short, specific descriptions derived from each image's caption and surrounding step text, e.g. `alt="Approvals page listing pending devices in the Pangolin dashboard"`
- No "image of…" / "picture of…" prefixes
- External products named where shown (Azure portal, Google Cloud console, AWS console, Cloudflare dashboard, Advantech router UI)
- Only `alt` attributes inserted — no other content or formatting touched

## Verification

- `mint a11y` MDX check: **success — no accessibility issues found** (was 36 issues)
- `mint validate`: build validation passed
- `mint broken-links`: no broken links
- Zero visual change to the rendered site

The color-contrast half of #116 is addressed separately in a follow-up PR (dark mode support).