### PR TITLE
feat: add dark mode support and fix a11y color contrast

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
     "description": "Zero trust access to all your infrastructure, self-hosted applications, and SaaS tools. Easy to deploy and scale. Better than your existing VPN.",
     "colors": {
         "primary": "#202020",
-        "light": "#202020",
+        "light": "#FF7A33",
         "dark": "#F36117"
     },
     "background": {
@@ -15,7 +15,10 @@
     },
     "styling": {
         "codeblocks": {
-            "theme": "gruvbox-light-hard"
+            "theme": {
+                "light": "gruvbox-light-hard",
+                "dark": "gruvbox-dark-hard"
+            }
         }
     },
     "favicon": "/favicon.png",
@@ -324,7 +327,7 @@
     },
     "appearance": {
         "default": "light",
-        "strict": true
+        "strict": false
     },
     "logo": {
         "light": "/logo/light.png",

--- a/style.css
+++ b/style.css
@@ -272,3 +272,78 @@
   #footer div[class*="1px"] {
     display: none !important;
   }
+
+  html.dark {
+    --pangolin-code-bg: #161616;
+    --pangolin-code-border: #3A3A3A;
+    --pangolin-code-inline-fg: #E8E7E5;
+  }
+
+  html.dark #content-area .code-block [data-testid="copy-code-button"]:hover,
+  html.dark #content-area .code-group [data-testid="copy-code-button"]:hover {
+    background-color: #2A2A2A !important;
+  }
+
+  html.dark #content-area .code-group {
+    border-color: #2A2A2A !important;
+  }
+
+  html.dark #content-area [data-component-part="code-group-tab-bar"] [role="tab"][data-state="active"] {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+  }
+
+  html.dark #content-area .frame {
+    border-color: rgba(255, 255, 255, 0.1) !important;
+  }
+
+  html.dark #content-area .callout::before {
+    background-color: #2A2A2A !important;
+  }
+
+  html.dark #table-of-contents > *:last-child {
+    background-color: #161616;
+  }
+
+  html.dark #navbar .max-w-8xl {
+    background-color: #161616;
+    border-bottom-color: #2A2A2A;
+  }
+
+  html.dark #sidebar {
+    background-color: #161616;
+  }
+
+  html.dark #header {
+    border-bottom-color: #2A2A2A;
+  }
+
+  html.dark #content-area .mt-8 .block {
+    background-color: #161616;
+  }
+
+  html.dark [data-component-part="step-number"] .rounded-full,
+  html.dark [data-component-part="step-number"] .bg-gray-50,
+  html.dark [data-component-part="step-number"] .dark\:bg-white\/10 {
+    background-color: #242424 !important;
+  }
+
+  /* Keep the dark pill button visible on the dark navbar */
+  html.dark #topbar-cta-button .group .absolute,
+  html.dark #topbar-cta-button a {
+    background-color: #202020 !important;
+    border: 1px solid #3A3A3A !important;
+  }
+
+  html.dark #footer {
+    background-color: #161616;
+    border-color: #2A2A2A !important;
+  }
+
+  html.dark #footer .border-t {
+    border-color: #2A2A2A !important;
+  }
+
+  html.dark #footer .bg-gray-100,
+  html.dark #footer .dark\:bg-white\/5 {
+    background-color: #242424 !important;
+  }


### PR DESCRIPTION
## Summary

Closes #116 (color contrast; the missing image alt attributes are addressed in #133).

`mint a11y` reports a color contrast failure: the dark-mode accent (`colors.light`) was `#202020` — near-black on a near-black background, 1.22:1 (minimum is 4.5:1). Investigating revealed the root cause: **dark mode is locked off** (`appearance.strict: true`) because the custom `style.css` was only ever styled for light mode. This PR fixes the root cause rather than just the reported symptom.

## The problem is bigger than the reported contrast failure

The screenshots below show what dark mode actually looks like the moment it is enabled — the contrast number from the issue is only one symptom. Fixing only `colors.light` would still leave dark mode unusable, which is why this PR also touches `style.css` and the code-block theme.

**Screenshot 1 — broken surfaces:** the custom CSS hardcodes light-only colors, so the navbar and sidebar stay cream on a dark page, and the table-of-contents card renders white-on-white, unreadable text.

<!-- drag darkmodeissue1.png here -->
<img width="1683" height="839" alt="darkmodeissue1" src="https://github.com/user-attachments/assets/22141a55-c07b-42e9-b7b2-c62234f18fcc" />


**Screenshot 2 — unreadable text in code blocks:** the site configures a single, light syntax-highlighting theme (`gruvbox-light-hard`), so in dark mode code is painted with dark text on a dark background. Plain-text blocks (no language tag) are nearly invisible; `bash`/`yaml` blocks only stay legible by luck of their token colors. This PR fixes the text colors by adding a dark counterpart theme (`gruvbox-dark-hard`) and flipping the shared text variable (`--pangolin-code-inline-fg`: `#202020` → `#E8E7E5`) so inline code, callout text, and code-group tabs are light in dark mode.

<!-- drag darkmodeissue2.png here -->
<img width="1550" height="846" alt="darkmodeissue2" src="https://github.com/user-attachments/assets/ec8b6aa6-b508-45b4-803b-8d9e5e079609" />



## Changes

**`docs.json`**
- `colors.light`: `#202020` → `#FF7A33` — contrast vs dark background now **7.54:1 (WCAG AAA)**
- `appearance.strict`: `true` → `false` — enables the built-in light/dark toggle
- `styling.codeblocks.theme`: adds `gruvbox-dark-hard` for dark mode (light mode keeps `gruvbox-light-hard` unchanged)

**`style.css`**
- New `html.dark` section mirroring the existing light palette, reusing the repo's own CSS variables and selectors: surfaces `#F2F0E7` → `#161616`, borders `#E8E7E5` → `#2A2A2A`, text `#202020` → `#E8E7E5`
- The "Start for free" button keeps its original `#202020`; in dark mode it gains a subtle `#3A3A3A` outline so it stays visible on the dark navbar

## Notes for reviewers

- The dark gray values are a proposal that mirrors the light palette's relationships — happy to swap in official brand values if they exist.
- **One-line revert:** setting `appearance.strict: true` disables dark mode again for visitors without losing any of the fixes.
- Light mode is visually unchanged.

## Verification

- `mint a11y`: **Overall Assessment: PASS — all colors meet accessibility standards** (light color 7.54:1, AAA)
- `mint validate` and `mint broken-links`: pass
- Both modes verified manually in the browser (navbar, sidebar, footer, code blocks, callouts, TOC card)