### PR TITLE
Make 'path' field required in response field

### DIFF
--- a/manage/blueprints.mdx
+++ b/manage/blueprints.mdx
@@ -1077,7 +1077,7 @@ public-resources:
                 Enables health checking for the target.
               </ResponseField>
 
-              <ResponseField name="path" type="string">
+              <ResponseField name="path" type="string" required>
                 HTTP path to check, such as `/health`.
               </ResponseField>
 


### PR DESCRIPTION
This PR marks the 'path' field as required in the blueprints documentation.

My findings as per (https://github.com/fosrl/pangolin/issues/3484) are that without specifying the path when creating a health check via blueprint labels, the health check will remain in an Unknown state unless the user toggles the health check off/on in the UI.

Now, it may not truly be the case that path is required in terms of the underlying data model, but since the health check won't come up properly without this parameter, it seems to me to be de-facto required.

No worries if you feel otherwise and decide to close the PR. Regardless, thanks for your great work on Pangolin!